### PR TITLE
Fix chunk ending in delimiter

### DIFF
--- a/lib/X12parser.js
+++ b/lib/X12parser.js
@@ -92,7 +92,9 @@ class X12parser extends Transform {
    * @returns {string[]} An array of segments
    */
   splitSegments(rawString) {
-    return rawString.split(this._delimiters.segment);
+    // Make sure there are not delimiters at start or end of the string
+    const cleanedString = this.removeDelimiters(rawString);
+    return cleanedString.split(this._delimiters.segment);
   }
 
   /**
@@ -112,14 +114,16 @@ class X12parser extends Transform {
       this._firstLine = false;
     }
 
-    // Make sure there are not delimiters at start or end of the string
-    data = this.removeDelimiters(data);
-
     // Get array segments
     const segments = this.splitSegments(data);
 
     // Store last segment, it may not be a full segment and should be processed w/ next chunk
     this._leftOver = segments.splice(-1, 1)[0];
+
+    // Add delimiter back if chunk ended with a delimiter
+    if (data[data.length - 1] === this._delimiters.segment) {
+      this._leftOver += this._delimiters.segment;
+    }
 
     // Generate and push data in stream
     this.generateSegments(segments);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "vitest ./test",
+    "test": "vitest",
     "test:coverage": "vitest run --coverage ./test",
     "docs": "jsdoc -c jsdoc.json",
     "format": "prettier --write ./lib ./test --loglevel warn",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,10 +12,11 @@ export default defineConfig({
       extension: ['.js'],
       // Apply current coverage levels to prevent drops
       // TODO: So close to 100%
-      lines: 90,
-      statements: 84,
-      branches: 94,
-      functions: 84,
+      lines: 98,
+      statements: 97,
+      branches: 95,
+      functions: 97,
     },
+    mockReset: true,
   },
 });


### PR DESCRIPTION
If a chunk ended with the delimiter it would combine the prev segment with the new one, to fix this we add the ending segment back to prev chunk data.

Thanks to [@SirCoolness](https://github.com/SirCoolness) for reporting and suggesting the fix for this. Since I switched the default branch to main I setup a new PR instead of merging https://github.com/tastypackets/x12-parser/pull/21.