### PR TITLE
fix: alias imports in built code

### DIFF
--- a/lib/Group.ts
+++ b/lib/Group.ts
@@ -3,7 +3,7 @@ import type {
   GroupShape,
   GroupOrSegment,
   GroupData,
-} from '@/types.js';
+} from './types.js';
 
 export class Group {
   #schema: GroupShape;

--- a/lib/Schema.ts
+++ b/lib/Schema.ts
@@ -1,4 +1,4 @@
-import type { GroupShape } from '@/types.js';
+import type { GroupShape } from './types.js';
 
 export class Schema {
   #version: string;

--- a/lib/Segment.ts
+++ b/lib/Segment.ts
@@ -1,4 +1,4 @@
-import type { Delimiters, FormattedSegment } from '@/types.js';
+import type { Delimiters, FormattedSegment } from './types.js';
 
 export class Segment {
   #delimiters: Delimiters;

--- a/lib/X12grouper.ts
+++ b/lib/X12grouper.ts
@@ -1,8 +1,8 @@
 import { Transform } from 'node:stream';
 
-import { Schema } from '@/Schema.js';
-import { Group } from '@/Group.js';
-import type { FormattedSegment } from '@/types.js';
+import { Schema } from './Schema.js';
+import { Group } from './Group.js';
+import type { FormattedSegment } from './types.js';
 
 export class X12grouper extends Transform {
   #schemas: Schema[];

--- a/lib/X12parser.ts
+++ b/lib/X12parser.ts
@@ -1,8 +1,8 @@
 import { Transform } from 'node:stream';
 import { StringDecoder } from 'node:string_decoder';
 
-import { Segment } from '@/Segment.js';
-import type { Delimiters } from '@/types.js';
+import { Segment } from './Segment.js';
+import type { Delimiters } from './types.js';
 
 export class X12parser extends Transform {
   #decoder: StringDecoder;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "x12-parser",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "x12-parser",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.5.5",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "check:spelling": "cspell ."
   },
   "name": "x12-parser",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "NodeJS X12 parser using streams",
   "main": "dist/cjs/index.js",
   "exports": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,12 @@
 {
   "compilerOptions": {
-    "baseUrl": "lib",
     "allowJs": false,
     "strict": true,
     "declaration": true,
     "module": "NodeNext",
     "skipLibCheck": true,
     "lib": ["es2023"],
-    "target": "es2022",
-    "paths": {
-      "@/*": ["*"]
-    }
+    "target": "es2022"
   },
   "include": ["lib"]
 }


### PR DESCRIPTION
- There was aliases `@` in the output build code causing errors, these were only intended for tests.