### PR TITLE
chore: refactor old callback syntax to async/await in tests and readme

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -2,6 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/v8.14.2/cspell.schema.json",
   "version": "0.2",
   "language": "en",
-  "words": ["Keator", "EMEDNYBAT", "ETIN"],
+  "words": ["Keator", "EMEDNYBAT", "ETIN", "Stringifier"],
   "ignorePaths": ["test", "dist", "coverage", "node_modules"]
 }

--- a/test/callback-test.ts
+++ b/test/callback-test.ts
@@ -1,6 +1,0 @@
-import { it } from 'vitest';
-
-export const it_cb = (
-  name: string,
-  testMethod: (done: CallableFunction) => void
-) => it(name, () => new Promise((done) => testMethod(done)));


### PR DESCRIPTION
Test Refactoring
- All callback-based tests have been converted to use async/await.

README Updates
- Updated code examples to with async/await closes #52
- Added stream/promises example.
- Corrected inaccuracies in the X12parser constructor usage and the pipe() method name.