### PR TITLE
Modifying segment parsing to handle repetition with elements.

### DIFF
--- a/test/segment.test.ts
+++ b/test/segment.test.ts
@@ -21,14 +21,25 @@ describe('Segment', () => {
     it('Should return an array of strings, split by the component delimiter', () => {
       //TODO: Remove initial segment when type checking is added
       const mySegment = new Segment('AMT*AU*34.25', delimiters);
-      expect(mySegment.processElement('AU')).toStrictEqual(['AU']);
+      expect(mySegment.processElement('AU')).toStrictEqual([['AU']]);
     });
     it('If ISA component is left in tact, since it is an actual element', () => {
       //TODO: Remove initial segment when type checking is added
       const isa =
         'ISA*00*          *00*          *ZZ*EMEDNYBAT      *ZZ*ETIN           *100101*1000*^*00501*006000600*0*T*:';
       const mySegment = new Segment(isa, delimiters);
-      expect(mySegment.processElement(':')).toStrictEqual([':']);
+      expect(mySegment.processElement(':')).toStrictEqual([[':']]);
+    });
+    it('Should handle cases where elements are repeated', () => {
+      const ras = 'RAS*34.25*1234567890*12345:0^67890:1';
+      const mySegment = new Segment(ras, delimiters);
+      expect(mySegment.processElement('1234567890')).toStrictEqual([
+        ['1234567890'],
+      ]);
+      expect(mySegment.processElement('12345:0^67890:1')).toStrictEqual([
+        ['12345', '0'],
+        ['67890', '1'],
+      ]);
     });
   });
 
@@ -50,7 +61,7 @@ describe('Segment', () => {
   describe('#constructor()', () => {
     const mySegment = new Segment('AMT*AU*34.25', delimiters);
     it('Should parse passed raw element string', () => {
-      expect(mySegment.parsed).toStrictEqual([['AU'], ['34.25']]);
+      expect(mySegment.parsed).toStrictEqual([[['AU']], [['34.25']]]);
     });
 
     it('Should parse out the name of the element', () => {
@@ -65,6 +76,46 @@ describe('Segment', () => {
         name: 'AMT',
         1: 'AU',
         2: '34.25',
+      });
+    });
+    it('Should add repeat index to end if repeated element', () => {
+      const ras = 'RAS*34.25*1234567890*12345:0^67890:1';
+      const segment = new Segment(ras, delimiters);
+      expect(segment.formatted).toStrictEqual({
+        name: 'RAS',
+        1: '34.25',
+        2: '1234567890',
+        3: '12345',
+        '3-1-1': '0',
+        '3-1-2': '67890',
+        '3-2-2': '1',
+      });
+    });
+    it('Should add repeat index to if repeated and first is single component', () => {
+      const ras = 'RAS*34.25*1234567890*abcde^12345:0^67890:1';
+      const segment = new Segment(ras, delimiters);
+      expect(segment.formatted).toStrictEqual({
+        name: 'RAS',
+        1: '34.25',
+        2: '1234567890',
+        3: 'abcde',
+        '3-1-2': '12345',
+        '3-2-2': '0',
+        '3-1-3': '67890',
+        '3-2-3': '1',
+      });
+    });
+    it('Should format normal multi component elements', () => {
+      const ras = 'RAS*34.25*1234567890*12345:0:67890:1';
+      const segment = new Segment(ras, delimiters);
+      expect(segment.formatted).toStrictEqual({
+        name: 'RAS',
+        1: '34.25',
+        2: '1234567890',
+        3: '12345',
+        '3-1': '0',
+        '3-2': '67890',
+        '3-3': '1',
       });
     });
   });


### PR DESCRIPTION
# Original Issue
The parsing of individual segments did not handle cases where the elements were repeated. (See example below.)
Under the current implementation in the event that an element is repeated the element is not fully parsed. The repetition delimiters are still left in the element. Additionally if the repeated element has components then parsing incorrectly splits by the component delimiter before splitting out each of the repeated elements. Please see the example below.
### Example
The following is an example of the X12 RAS segment based on documentation for X12 Release 8010. More information can be found at the [stedi documentation page](https://www.stedi.com/edi/x12/segment/RAS). 

Based on the documentation the RAS-03 element can repeat up to 15 times and the element itself is a composite with multiple components. 

The segment is as follows:
```
RAS*34.25*1234567890*12345:0^67890:1
```
Based on documentation the segment elements are:
- RAS-01 - `34.25`
- RAS-02 - `1234567890`
- RAS-03 (repeat 1) - `12345:0` &rarr; this has sub components `12345` and `0`
- RAS-03 (repeat 2) - `67890:1` &rarr; this has sub components `67890` and `1`

However under the current implementation a parsed segment will not split by the repetition delimiter and will produce the following:
```javascript
{
  '1': '34.25',
  '2': '1234567890',
  '3': '12345',
  name: 'RAS',
  '3-1': '0^67890',
  '3-2': '1'
}
```
## Fix
To address this issue I turned the parsed field of a segment into a 3D array (was a 2D array). Now the first layer of parsed represents each of the unique element types. The second represents the list of elements that are repeated (e.g. the list of RAS-03 elements that repeat), in most cases this will only have one value. The third layer will be the list of components for each of the elements.

Additionally to depict the repetition while also keeping compatibility I added a to the formatted value so that the index of the repeated element appears AT THE END. This way all the previous formats will remain the same. 
For example:
- `RAS*a` still appears as `{ name: 'RAS', 1: 'a' }`,
- `RAS*a:b:c` still appears as `{ name: 'RAS', 1: 'a', '1-1': 'b', '1-2': 'c' }`

But now:
- `RAS*a:b^c:d` appears as `{ name: 'RAS', 1: 'a', '1-1-1': 'b', '1-1-2': 'c', '1-2-2': 'd' }`
- `RAS*a^c:d` appears as `{ name: 'RAS', 1: 'a', '1-1-2': 'c', '1-2-2': 'd' }`
- `RAS*a^b^c` appears as `{ name: 'RAS', 1: 'a', '1-1-2': 'b', '1-1-3': 'c' }`


